### PR TITLE
[Android] Use StringSet in SharedPreferences

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -451,10 +451,7 @@ public class FlutterLocalNotificationsPlugin
     AlarmManager alarmManager = getAlarmManager(context);
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
       AlarmManagerCompat.setAlarmClock(
-          alarmManager,
-          notificationDetails.millisecondsSinceEpoch,
-          pendingIntent,
-          pendingIntent);
+          alarmManager, notificationDetails.millisecondsSinceEpoch, pendingIntent, pendingIntent);
     } else {
       AlarmManagerCompat.setExact(
           alarmManager,
@@ -492,8 +489,7 @@ public class FlutterLocalNotificationsPlugin
                 .toInstant()
                 .toEpochMilli();
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setAlarmClock(
-          alarmManager, epochMilli, pendingIntent, pendingIntent);
+      AlarmManagerCompat.setAlarmClock(alarmManager, epochMilli, pendingIntent, pendingIntent);
     } else {
       AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, epochMilli, pendingIntent);
     }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -84,6 +84,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -615,19 +616,18 @@ public class FlutterLocalNotificationsPlugin
     return repeatInterval;
   }
 
-  // TODO don't json parse the whole list, but this will allow duplicate notifications with the same id
+  // Don't json parse the whole list, but this will allow duplicate notifications with the same id
   private static void saveScheduledNotification(
       Context context, NotificationDetails notificationDetails) {
-    ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(context);
-    ArrayList<NotificationDetails> scheduledNotificationsToSave = new ArrayList<>();
-    for (NotificationDetails scheduledNotification : scheduledNotifications) {
-      if (scheduledNotification.id.equals(notificationDetails.id)) {
-        continue;
-      }
-      scheduledNotificationsToSave.add(scheduledNotification);
-    }
-    scheduledNotificationsToSave.add(notificationDetails);
-    saveScheduledNotifications(context, scheduledNotificationsToSave);
+    SharedPreferences sharedPreferences =
+        context.getSharedPreferences(SCHEDULED_NOTIFICATIONS_SET, Context.MODE_PRIVATE);
+    Set<String> jsons = sharedPreferences.getStringSet(SCHEDULED_NOTIFICATIONS_SET, new HashSet<String>());
+    Set<String> newSet = new HashSet<String>(jsons);
+    Gson gson = buildGson();
+    newSet.add(gson.toJson(notificationDetails));
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+    editor.putStringSet(SCHEDULED_NOTIFICATIONS_SET, newSet);
+    editor.apply();
   }
 
   private static int getDrawableResourceId(Context context, String name) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -26,7 +26,6 @@ import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
-import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.core.app.AlarmManagerCompat;
@@ -433,9 +432,6 @@ public class FlutterLocalNotificationsPlugin
     String[] jsonNotificationsToSave = new String[amount];
     for (int i = 0; i < amount; i++) {
       jsonNotificationsToSave[i] = gson.toJson(notificationsList.get(i));
-      if (i == 0) {
-        logLongJson(jsonNotificationsToSave[i]);
-      }
     }
     Set<String> scheduledNotifications = Set.of(jsonNotificationsToSave);
     SharedPreferences.Editor editor = sharedPreferences.edit();
@@ -443,24 +439,6 @@ public class FlutterLocalNotificationsPlugin
     editor.putStringSet(SCHEDULED_NOTIFICATIONS_SET, scheduledNotifications);
     editor.apply();
     return scheduledNotifications;
-  }
-
-  private static void logLongJson(String json) {
-    String TAG = "json_example";
-    if (json.length() > 4000) {
-      Log.v(TAG, "sb.length = " + json.length());
-      int chunkCount = json.length() / 4000;     // integer division
-      for (int i = 0; i <= chunkCount; i++) {
-        int max = 4000 * (i + 1);
-        if (max >= json.length()) {
-          Log.v(TAG, json.substring(4000 * i));
-        } else {
-          Log.v(TAG, json.substring(4000 * i, max));
-        }
-      }
-    } else {
-      Log.v(TAG, json);
-    }
   }
 
   private static void saveScheduledNotifications(

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -450,10 +450,10 @@ public class FlutterLocalNotificationsPlugin
 
     AlarmManager alarmManager = getAlarmManager(context);
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setExactAndAllowWhileIdle(
+      AlarmManagerCompat.setAlarmClock(
           alarmManager,
-          AlarmManager.RTC_WAKEUP,
           notificationDetails.millisecondsSinceEpoch,
+          pendingIntent,
           pendingIntent);
     } else {
       AlarmManagerCompat.setExact(
@@ -492,8 +492,8 @@ public class FlutterLocalNotificationsPlugin
                 .toInstant()
                 .toEpochMilli();
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setExactAndAllowWhileIdle(
-          alarmManager, AlarmManager.RTC_WAKEUP, epochMilli, pendingIntent);
+      AlarmManagerCompat.setAlarmClock(
+          alarmManager, epochMilli, pendingIntent, pendingIntent);
     } else {
       AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, epochMilli, pendingIntent);
     }
@@ -515,8 +515,8 @@ public class FlutterLocalNotificationsPlugin
     PendingIntent pendingIntent =
         getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
     AlarmManager alarmManager = getAlarmManager(context);
-    AlarmManagerCompat.setExactAndAllowWhileIdle(
-        alarmManager, AlarmManager.RTC_WAKEUP, notificationTriggerTime, pendingIntent);
+    AlarmManagerCompat.setAlarmClock(
+        alarmManager, notificationTriggerTime, pendingIntent, pendingIntent);
     saveScheduledNotification(context, notificationDetails);
   }
 
@@ -568,8 +568,8 @@ public class FlutterLocalNotificationsPlugin
     AlarmManager alarmManager = getAlarmManager(context);
 
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setExactAndAllowWhileIdle(
-          alarmManager, AlarmManager.RTC_WAKEUP, notificationTriggerTime, pendingIntent);
+      AlarmManagerCompat.setAlarmClock(
+          alarmManager, notificationTriggerTime, pendingIntent, pendingIntent);
     } else {
       alarmManager.setInexactRepeating(
           AlarmManager.RTC_WAKEUP, notificationTriggerTime, repeatInterval, pendingIntent);


### PR DESCRIPTION
This makes adding notifications much faster by avoiding parsing JSON unnecessarily. Further improvements to the encoding of the SharedPreferences will also improve the speed of cancelling specific notifications.