### PR TITLE
[Android] Improved performance + Batch schedule

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -451,10 +451,7 @@ public class FlutterLocalNotificationsPlugin
     AlarmManager alarmManager = getAlarmManager(context);
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
       AlarmManagerCompat.setAlarmClock(
-          alarmManager,
-          notificationDetails.millisecondsSinceEpoch,
-          pendingIntent,
-          pendingIntent);
+          alarmManager, notificationDetails.millisecondsSinceEpoch, pendingIntent, pendingIntent);
     } else {
       AlarmManagerCompat.setExact(
           alarmManager,
@@ -492,8 +489,7 @@ public class FlutterLocalNotificationsPlugin
                 .toInstant()
                 .toEpochMilli();
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setAlarmClock(
-          alarmManager, epochMilli, pendingIntent, pendingIntent);
+      AlarmManagerCompat.setAlarmClock(alarmManager, epochMilli, pendingIntent, pendingIntent);
     } else {
       AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, epochMilli, pendingIntent);
     }

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -84,6 +84,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -615,19 +616,18 @@ public class FlutterLocalNotificationsPlugin
     return repeatInterval;
   }
 
-  // TODO don't json parse the whole list, but this will allow duplicate notifications with the same id
+  // Don't json parse the whole list, but this will allow duplicate notifications with the same id
   private static void saveScheduledNotification(
       Context context, NotificationDetails notificationDetails) {
-    ArrayList<NotificationDetails> scheduledNotifications = loadScheduledNotifications(context);
-    ArrayList<NotificationDetails> scheduledNotificationsToSave = new ArrayList<>();
-    for (NotificationDetails scheduledNotification : scheduledNotifications) {
-      if (scheduledNotification.id.equals(notificationDetails.id)) {
-        continue;
-      }
-      scheduledNotificationsToSave.add(scheduledNotification);
-    }
-    scheduledNotificationsToSave.add(notificationDetails);
-    saveScheduledNotifications(context, scheduledNotificationsToSave);
+    SharedPreferences sharedPreferences =
+        context.getSharedPreferences(SCHEDULED_NOTIFICATIONS_SET, Context.MODE_PRIVATE);
+    Set<String> jsons = sharedPreferences.getStringSet(SCHEDULED_NOTIFICATIONS_SET, new HashSet<String>());
+    Set<String> newSet = new HashSet<String>(jsons);
+    Gson gson = buildGson();
+    newSet.add(gson.toJson(notificationDetails));
+    SharedPreferences.Editor editor = sharedPreferences.edit();
+    editor.putStringSet(SCHEDULED_NOTIFICATIONS_SET, newSet);
+    editor.apply();
   }
 
   private static int getDrawableResourceId(Context context, String name) {

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -26,7 +26,6 @@ import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
-import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.core.app.AlarmManagerCompat;
@@ -433,9 +432,6 @@ public class FlutterLocalNotificationsPlugin
     String[] jsonNotificationsToSave = new String[amount];
     for (int i = 0; i < amount; i++) {
       jsonNotificationsToSave[i] = gson.toJson(notificationsList.get(i));
-      if (i == 0) {
-        logLongJson(jsonNotificationsToSave[i]);
-      }
     }
     Set<String> scheduledNotifications = Set.of(jsonNotificationsToSave);
     SharedPreferences.Editor editor = sharedPreferences.edit();
@@ -443,24 +439,6 @@ public class FlutterLocalNotificationsPlugin
     editor.putStringSet(SCHEDULED_NOTIFICATIONS_SET, scheduledNotifications);
     editor.apply();
     return scheduledNotifications;
-  }
-
-  private static void logLongJson(String json) {
-    String TAG = "json_example";
-    if (json.length() > 4000) {
-      Log.v(TAG, "sb.length = " + json.length());
-      int chunkCount = json.length() / 4000;     // integer division
-      for (int i = 0; i <= chunkCount; i++) {
-        int max = 4000 * (i + 1);
-        if (max >= json.length()) {
-          Log.v(TAG, json.substring(4000 * i));
-        } else {
-          Log.v(TAG, json.substring(4000 * i, max));
-        }
-      }
-    } else {
-      Log.v(TAG, json);
-    }
   }
 
   private static void saveScheduledNotifications(

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -397,8 +397,7 @@ public class FlutterLocalNotificationsPlugin
     ArrayList<NotificationDetails> scheduledNotifications = new ArrayList<>();
     SharedPreferences sharedPreferences =
         context.getSharedPreferences(SCHEDULED_NOTIFICATIONS_FILE, Context.MODE_PRIVATE);
-    Map<String, String> jsonNotifications =
-            (Map<String, String>) sharedPreferences.getAll();
+    Map<String, String> jsonNotifications = (Map<String, String>) sharedPreferences.getAll();
     if (jsonNotifications != null) {
       Gson gson = buildGson();
       Type type = new TypeToken<NotificationDetails>() {}.getType();
@@ -467,7 +466,11 @@ public class FlutterLocalNotificationsPlugin
       Context context,
       final NotificationDetails notificationDetails,
       Boolean updateScheduledNotificationsCache) {
-    scheduleNotificationAtTime(context, notificationDetails, notificationDetails.millisecondsSinceEpoch, updateScheduledNotificationsCache);
+    scheduleNotificationAtTime(
+        context,
+        notificationDetails,
+        notificationDetails.millisecondsSinceEpoch,
+        updateScheduledNotificationsCache);
   }
 
   private static void zonedScheduleNotification(
@@ -475,31 +478,32 @@ public class FlutterLocalNotificationsPlugin
       final NotificationDetails notificationDetails,
       Boolean updateScheduledNotificationsCache) {
     long epochMilli =
-            VERSION.SDK_INT >= VERSION_CODES.O
-                    ? ZonedDateTime.of(
+        VERSION.SDK_INT >= VERSION_CODES.O
+            ? ZonedDateTime.of(
                     LocalDateTime.parse(notificationDetails.scheduledDateTime),
                     ZoneId.of(notificationDetails.timeZoneName))
-                    .toInstant()
-                    .toEpochMilli()
-                    : org.threeten.bp.ZonedDateTime.of(
+                .toInstant()
+                .toEpochMilli()
+            : org.threeten.bp.ZonedDateTime.of(
                     org.threeten.bp.LocalDateTime.parse(notificationDetails.scheduledDateTime),
                     org.threeten.bp.ZoneId.of(notificationDetails.timeZoneName))
-                    .toInstant()
-                    .toEpochMilli();
-    scheduleNotificationAtTime(context, notificationDetails, epochMilli, updateScheduledNotificationsCache);
+                .toInstant()
+                .toEpochMilli();
+    scheduleNotificationAtTime(
+        context, notificationDetails, epochMilli, updateScheduledNotificationsCache);
   }
 
   private static void scheduleNotificationAtTime(
-          Context context,
-          NotificationDetails notificationDetails,
-          long epochMilli,
-          Boolean updateScheduledNotificationsCache) {
+      Context context,
+      NotificationDetails notificationDetails,
+      long epochMilli,
+      Boolean updateScheduledNotificationsCache) {
     Gson gson = buildGson();
     String notificationDetailsJson = gson.toJson(notificationDetails);
     Intent notificationIntent = new Intent(context, ScheduledNotificationReceiver.class);
     notificationIntent.putExtra(NOTIFICATION_DETAILS, notificationDetailsJson);
     PendingIntent pendingIntent =
-            getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
+        getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
 
     AlarmManager alarmManager = getAlarmManager(context);
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
@@ -1445,11 +1449,12 @@ public class FlutterLocalNotificationsPlugin
     zonedScheduleDetails(result, notificationDetails, applicationContext);
   }
 
-  private static void zonedScheduleDetails(Result result, NotificationDetails notificationDetails, Context applicationContext) {
+  private static void zonedScheduleDetails(
+      Result result, NotificationDetails notificationDetails, Context applicationContext) {
     if (notificationDetails != null) {
       if (notificationDetails.matchDateTimeComponents != null) {
         notificationDetails.scheduledDateTime =
-                getNextFireDateMatchingDateTimeComponents(notificationDetails);
+            getNextFireDateMatchingDateTimeComponents(notificationDetails);
       }
       zonedScheduleNotification(applicationContext, notificationDetails, true);
       result.success(null);
@@ -1459,7 +1464,8 @@ public class FlutterLocalNotificationsPlugin
   private void zonedScheduleMultiple(MethodCall call, Result result) {
     Map<String, Object> arguments = call.arguments();
     boolean replace = arguments.get(REPLACE);
-    ArrayList<NotificationDetails> multiNotificationDetails = extractMultipleNotificationDetails(result, arguments);
+    ArrayList<NotificationDetails> multiNotificationDetails =
+        extractMultipleNotificationDetails(result, arguments);
 
     if (replace) {
       cancelAllPendingNotifications();
@@ -1642,14 +1648,11 @@ public class FlutterLocalNotificationsPlugin
     result.success(null);
   }
 
-  /**
-   * Cancels all pending notifications without parsing any JSON
-   */
+  /** Cancels all pending notifications without parsing any JSON */
   private void cancelAllPendingNotifications() {
     SharedPreferences sharedPreferences =
         applicationContext.getSharedPreferences(SCHEDULED_NOTIFICATIONS_FILE, Context.MODE_PRIVATE);
-    Map<String, String> jsonNotifications =
-            (Map<String, String>) sharedPreferences.getAll();
+    Map<String, String> jsonNotifications = (Map<String, String>) sharedPreferences.getAll();
 
     if (jsonNotifications.isEmpty()) {
       return;
@@ -1660,8 +1663,7 @@ public class FlutterLocalNotificationsPlugin
     for (String id : jsonNotifications.keySet()) {
       // TODO filter out non-matching IDs
       int intId = Integer.parseInt(id.substring(SCHEDULED_NOTIFICATIONS_ID.length() - 1));
-      PendingIntent pendingIntent =
-          getBroadcastPendingIntent(applicationContext, intId, intent);
+      PendingIntent pendingIntent = getBroadcastPendingIntent(applicationContext, intId, intent);
       alarmManager.cancel(pendingIntent);
     }
 

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -450,10 +450,10 @@ public class FlutterLocalNotificationsPlugin
 
     AlarmManager alarmManager = getAlarmManager(context);
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setExactAndAllowWhileIdle(
+      AlarmManagerCompat.setAlarmClock(
           alarmManager,
-          AlarmManager.RTC_WAKEUP,
           notificationDetails.millisecondsSinceEpoch,
+          pendingIntent,
           pendingIntent);
     } else {
       AlarmManagerCompat.setExact(
@@ -492,8 +492,8 @@ public class FlutterLocalNotificationsPlugin
                 .toInstant()
                 .toEpochMilli();
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setExactAndAllowWhileIdle(
-          alarmManager, AlarmManager.RTC_WAKEUP, epochMilli, pendingIntent);
+      AlarmManagerCompat.setAlarmClock(
+          alarmManager, epochMilli, pendingIntent, pendingIntent);
     } else {
       AlarmManagerCompat.setExact(alarmManager, AlarmManager.RTC_WAKEUP, epochMilli, pendingIntent);
     }
@@ -515,8 +515,8 @@ public class FlutterLocalNotificationsPlugin
     PendingIntent pendingIntent =
         getBroadcastPendingIntent(context, notificationDetails.id, notificationIntent);
     AlarmManager alarmManager = getAlarmManager(context);
-    AlarmManagerCompat.setExactAndAllowWhileIdle(
-        alarmManager, AlarmManager.RTC_WAKEUP, notificationTriggerTime, pendingIntent);
+    AlarmManagerCompat.setAlarmClock(
+        alarmManager, notificationTriggerTime, pendingIntent, pendingIntent);
     saveScheduledNotification(context, notificationDetails);
   }
 
@@ -568,8 +568,8 @@ public class FlutterLocalNotificationsPlugin
     AlarmManager alarmManager = getAlarmManager(context);
 
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
-      AlarmManagerCompat.setExactAndAllowWhileIdle(
-          alarmManager, AlarmManager.RTC_WAKEUP, notificationTriggerTime, pendingIntent);
+      AlarmManagerCompat.setAlarmClock(
+          alarmManager, notificationTriggerTime, pendingIntent, pendingIntent);
     } else {
       alarmManager.setInexactRepeating(
           AlarmManager.RTC_WAKEUP, notificationTriggerTime, repeatInterval, pendingIntent);

--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -412,11 +412,11 @@ public class FlutterLocalNotificationsPlugin
   /**
    * Get scheduled notifications from shared preferences, converting from old format if present.
    *
-   * Returns null if neither are present
-   * The returned Set may not be mutated!
+   * <p>Returns null if neither are present The returned Set may not be mutated!
    */
   private static Set<String> getScheduledNotificationsJsonSet(SharedPreferences sharedPreferences) {
-    Set<String> jsonNotifications = sharedPreferences.getStringSet(SCHEDULED_NOTIFICATIONS_SET, null);
+    Set<String> jsonNotifications =
+        sharedPreferences.getStringSet(SCHEDULED_NOTIFICATIONS_SET, null);
     if (jsonNotifications != null) {
       return jsonNotifications;
     }
@@ -1656,12 +1656,10 @@ public class FlutterLocalNotificationsPlugin
     removeNotificationFromCache(applicationContext, id);
   }
 
-  /**
-   * Cancels only all pending notifications, leaving active ones.
-   */
+  /** Cancels only all pending notifications, leaving active ones. */
   private void cancelAllPendingNotifications(Result result) {
     ArrayList<NotificationDetails> scheduledNotifications =
-            loadScheduledNotifications(applicationContext);
+        loadScheduledNotifications(applicationContext);
     if (scheduledNotifications.isEmpty()) {
       result.success(null);
       return;
@@ -1671,12 +1669,12 @@ public class FlutterLocalNotificationsPlugin
     AlarmManager alarmManager = getAlarmManager(applicationContext);
     for (NotificationDetails scheduledNotification : scheduledNotifications) {
       PendingIntent pendingIntent =
-              getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
+          getBroadcastPendingIntent(applicationContext, scheduledNotification.id, intent);
       alarmManager.cancel(pendingIntent);
     }
 
     SharedPreferences sharedPreferences =
-            applicationContext.getSharedPreferences(SCHEDULED_NOTIFICATIONS_FILE, Context.MODE_PRIVATE);
+        applicationContext.getSharedPreferences(SCHEDULED_NOTIFICATIONS_FILE, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.remove(SCHEDULED_NOTIFICATIONS_SET);
     editor.apply();


### PR DESCRIPTION
This improves performance by greatly reducing the amount of JSON parsing and encoding needed to do the scheduling and removing of notifications. It does so by not saving one large JSON string in Shared Preferences, but adding a separate String key for each notification ID. 

It further improves performance and usability by exposing new functionality to flutter: the ability to schedule multiple notifications at once (optionally replacing any existing ones). 